### PR TITLE
Implementing Resources

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "rspec",
+      "type": "ruby",
+      "command": "rspec"
+    }
+  ]
+}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
     diff-lcs (1.3)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
+    method_source (1.0.0)
     multipart-post (2.1.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rake (12.3.3)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -31,6 +36,7 @@ PLATFORMS
 
 DEPENDENCIES
   mls_api!
+  pry
   rake (~> 12.0)
   rspec (~> 3.0)
 

--- a/lib/mls_api.rb
+++ b/lib/mls_api.rb
@@ -3,6 +3,8 @@
 require 'mls_api/version'
 require 'mls_api/mls_error'
 require 'mls_api/connection'
+require 'mls_api/resources/base'
+require 'mls_api/resources/property'
 require 'json'
 
 module MlsApi
@@ -18,19 +20,13 @@ module MlsApi
     def properties(params = {})
       response = @connection.get('/Property', params)
 
-      get_body(response)
+      Resources::Property.from_collection response.body
     end
 
     def property(listing_key)
       response = @connection.get("/Property('#{listing_key}')")
 
-      get_body(response)
+      Resources::Property.new response.body
     end
-
-    protected
-
-      def get_body(response)
-        JSON.parse(response.body)
-      end
   end
 end

--- a/lib/mls_api/resources/base.rb
+++ b/lib/mls_api/resources/base.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'json'
+
+module MlsApi
+  module Resources
+    ###
+    # @description: Class responsible to parse json response
+    # @param body: Faraday response body
+    ###
+    class Base < OpenStruct
+      def initialize(body)
+        @body = body.kind_of?(Hash) ? body : JSON.parse(body)
+        super(@body)
+      end
+
+      def key?(key)
+        @table.key?(key)
+      end
+
+      def self.from_collection(body)
+        json = JSON.parse(body)
+        json['value'].map{|property| self.new(property) }
+      end
+    end
+  end
+end

--- a/lib/mls_api/resources/property.rb
+++ b/lib/mls_api/resources/property.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+
+module MlsApi
+  module Resources
+    ###
+    # @description: Class responsible to parse json response
+    # @param connection: Faraday
+    ###
+    class Property < Base; end
+  end
+end

--- a/mls_api.gemspec
+++ b/mls_api.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.add_dependency 'faraday', '~> 1.0'
+  spec.add_development_dependency 'pry'
 end

--- a/spec/fixtures/files/property.txt
+++ b/spec/fixtures/files/property.txt
@@ -1,0 +1,7 @@
+{
+  "@odata.context": "https://api.bridgedataoutput.com/api/v2/OData/test/$metadata#Property",
+  "@odata.id": "https://api.bridgedataoutput.com/api/v2/OData/test/Property('P_5af601c3fc76173b348291e9')",
+  "ListingKey": "P_5af601c3fc76173b348291e9",
+  "ListingId": "5af601c3fc76173b348291ea",
+  "OriginatingSystemKey": "test"
+}

--- a/spec/mls_api_client_spec.rb
+++ b/spec/mls_api_client_spec.rb
@@ -16,7 +16,19 @@ RSpec.describe MlsApi::Client do
       ]
     end
 
-    expect(client.properties.key?('value')).to be true
-    expect(client.properties['value'].kind_of?(Array)).to be true
+    expect(client.properties.kind_of?(Array)).to be true
+  end
+
+  it 'gets property' do
+    stubs.get("/Property('P_5af601c3fc76173b348291e9')") do |env|
+      [
+        200,
+        { 'Content-Type': 'application/javascript' },
+        File.open("#{Dir.pwd}/spec/fixtures/files/property.txt").read
+      ]
+    end
+
+    property = client.property('P_5af601c3fc76173b348291e9')
+    expect(property.ListingKey).to eq('P_5af601c3fc76173b348291e9')
   end
 end

--- a/spec/resources/property_spec.rb
+++ b/spec/resources/property_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe MlsApi::Resources::Property do
+  let(:property) {
+    File.open("#{Dir.pwd}/spec/fixtures/files/property.txt").read
+  }
+  let(:properties) {
+    File.open("#{Dir.pwd}/spec/fixtures/files/properties.txt").read
+  }
+
+  it 'parse property' do
+    property_intance = described_class.new(property)
+
+    expect(property_intance.key?(:ListingKey)).to be true
+    expect(property_intance.ListingKey).to eq('P_5af601c3fc76173b348291e9')
+  end
+
+  it 'parse properties' do
+    property_collection = described_class.from_collection(properties)
+    first_property = property_collection.first
+
+    expect(property_collection.kind_of?(Array)).to be true
+    expect(first_property.kind_of?(described_class)).to be true
+    expect(first_property.key?(:ListingKey)).to be true
+    expect(first_property.ListingKey).to eq('P_5af601c3fc76173b348291e9')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "bundler/setup"
+require 'pry'
 require "mls_api"
 
 RSpec.configure do |config|


### PR DESCRIPTION
# What this PR do?

Inorder to get an object oriented response, I create resources classes bases OpenStruct for better attribute access

``` ruby
# instead of do
json['ListingKey']

# now uses
property = MlsApi::Resource::Property.new(json)
property.ListingKey # or property[:ListingKey]
```